### PR TITLE
Use DFTTest for smooth_dering's default smoothing

### DIFF
--- a/vsdehalo/denoise.py
+++ b/vsdehalo/denoise.py
@@ -17,7 +17,7 @@ __all__ = [
 
 def smooth_dering(
     clip: vs.VideoNode,
-    smooth: vs.VideoNode | Prefilter = Prefilter.MINBLUR1,
+    smooth: vs.VideoNode | Prefilter = Prefilter.DFTTEST_SMOOTH,
     ringmask: vs.VideoNode | None = None,
     mrad: int = 1, msmooth: int = 1, minp: int = 1, mthr: int = 60, incedge: bool = False,
     thr: int = 12, elast: float = 2.0, darkthr: int | None = None,


### PR DESCRIPTION
DFTTEST_SMOOTH is equivalent to the settings used for nrmode=0 in havsfunc.HQDeringMod--similarly, this should result in much higher retention of detail, whereas MinBlur (also the default in havsfunc) can cause considerable detail blurring.