### PR TITLE
fine_dehalo.mask: Add Lanczos pre_ss

### DIFF
--- a/vsdehalo/alpha.py
+++ b/vsdehalo/alpha.py
@@ -334,7 +334,8 @@ class _fine_dehalo:
             pre_ss = max(round(pre_ss), 2)
 
             work_clip = pre_supersampler.scale(
-                work_clip, work_clip.width * pre_ss, work_clip.height * pre_ss
+                work_clip, work_clip.width * pre_ss, work_clip.height * pre_ss,
+                (-(0.5 / pre_ss), -(0.5 / pre_ss))
             )
 
         dehalo_mask = self(
@@ -343,7 +344,7 @@ class _fine_dehalo:
         )
 
         if (dehalo_mask.width, dehalo_mask.height) != (clip.width, clip.height):
-            dehalo_mask = pre_downscaler.scale(work_clip, clip.width, clip.height, (0.5 / pre_ss, 0.5 / pre_ss))
+            dehalo_mask = pre_downscaler.scale(dehalo_mask, clip.width, clip.height)
 
         if dehaloed:
             return clip.std.MaskedMerge(dehaloed, dehalo_mask, planes, first_plane)

--- a/vsdehalo/alpha.py
+++ b/vsdehalo/alpha.py
@@ -296,8 +296,8 @@ class _fine_dehalo:
     def mask(
         self, clip: vs.VideoNode, dehaloed: vs.VideoNode | None = None,
         rx: int = 1, ry: int | None = None, thmi: int = 50, thma: int = 100, thlimi: int = 50, thlima: int = 100,
-        exclude: bool = True, edgeproc: float = 0.0, edgemask: EdgeDetect = Robinson3(), pre_ss: float = 1.0,
-        pre_supersampler: ScalerT = Bilinear, pre_downscaler: ScalerT = Point,
+        exclude: bool = True, edgeproc: float = 0.0, edgemask: EdgeDetect = Robinson3(), pre_ss: int = 1,
+        pre_supersampler: ScalerT = Bilinear,
         mask: int | FineDehaloMask = 1, planes: PlanesT = 0, first_plane: bool = False, func: FuncExceptT | None = None
     ) -> vs.VideoNode:
         """
@@ -318,7 +318,6 @@ class _fine_dehalo:
         :param get_mask:            Whether to show the computed halo mask. 1-7 values to select intermediate masks.
         :param pre_ss:              Supersampling rate used before anything else. This value will be be rounded.
         :param pre_supersampler:    Supersampler used for ``pre_ss``.
-        :param pre_downscaler:      Downscaler used for undoing the upscaling done by ``pre_supersampler``.
         :param planes:              Planes to process.
         :param first_plane:         Whether to mask chroma planes with luma mask.
         :param func:                Function from where this function was called.
@@ -344,7 +343,7 @@ class _fine_dehalo:
         )
 
         if (dehalo_mask.width, dehalo_mask.height) != (clip.width, clip.height):
-            dehalo_mask = pre_downscaler.scale(dehalo_mask, clip.width, clip.height)
+            dehalo_mask = Point.scale(dehalo_mask, clip.width, clip.height)
 
         if dehaloed:
             return clip.std.MaskedMerge(dehaloed, dehalo_mask, planes, first_plane)

--- a/vsdehalo/alpha.py
+++ b/vsdehalo/alpha.py
@@ -326,13 +326,10 @@ class _fine_dehalo:
         """
         work_clip = get_y(clip)
 
-        pre_supersampler = Scaler.ensure_obj(pre_supersampler, func)
-        pre_downscaler = Scaler.ensure_obj(pre_downscaler, func)
-
         if pre_ss > 1.0:
             pre_ss = max(round(pre_ss), 2)
 
-            work_clip = pre_supersampler.scale(
+            work_clip = Scaler.ensure_obj(pre_supersampler, func).scale(
                 work_clip, work_clip.width * pre_ss, work_clip.height * pre_ss,
                 (-(0.5 / pre_ss), -(0.5 / pre_ss))
             )

--- a/vsdehalo/alpha.py
+++ b/vsdehalo/alpha.py
@@ -4,7 +4,7 @@ from typing import Any, Sequence, final
 
 from vsaa import Nnedi3
 from vsexprtools import ExprOp, complexpr_available, combine, norm_expr
-from vskernels import BSpline, Lanczos, Mitchell, NoShift, Point, Scaler, ScalerT
+from vskernels import Bilinear, BSpline, Lanczos, Mitchell, NoShift, Point, Scaler, ScalerT
 from vsmasktools import EdgeDetect, Morpho, Robinson3, XxpandMode, grow_mask, retinex
 from vsrgtools import (
     box_blur, contrasharpening, contrasharpening_dehalo, repair, RemoveGrainMode, RepairMode, gauss_blur, limit_filter
@@ -297,7 +297,7 @@ class _fine_dehalo:
         self, clip: vs.VideoNode, dehaloed: vs.VideoNode | None = None,
         rx: int = 1, ry: int | None = None, thmi: int = 50, thma: int = 100, thlimi: int = 50, thlima: int = 100,
         exclude: bool = True, edgeproc: float = 0.0, edgemask: EdgeDetect = Robinson3(), pre_ss: float = 1.0,
-        pre_supersampler: ScalerT = Lanczos, pre_downscaler: ScalerT = Point,
+        pre_supersampler: ScalerT = Bilinear, pre_downscaler: ScalerT = Point,
         mask: int | FineDehaloMask = 1, planes: PlanesT = 0, first_plane: bool = False, func: FuncExceptT | None = None
     ) -> vs.VideoNode:
         """


### PR DESCRIPTION
This commit adds basic lanczos pre_ss functionality to `fine_dehalo.mask`. This should give you more accurate masking results (see [this comp](https://slow.pics/c/tJBxFjm8)).

I explicitly opted not to pass `pre_ss` params forward to `__call__`. This is for two reasons:

1. I don't want to adjust the behaviour of `fine_dehalo` at this moment. Possibly altering how it behaves may result in issues for user's scripts. I feel that if we're changing this, @setsugennoao should be the one to do it.
2. I want to move away from using nnedi3 for supersampling. It's faster than it's ever been, but faster options that give us similar results but should be faster. See [this discord message](https://discord.com/channels/985630730174472202/985644050893897728/1152641403919282257). The idea is primarily that at integer supersampling, Lanczos (and similar) will be interpolatory. This allows us to undo them. The only real catch is that we *must* do integer scaling, but the speed loss there is offset by Kernels generally being faster than Nnedi3. @Vodes also verified the results are the same as Nnedi3.

Hopefully this can be the start to us implementing this in other functions to speed things up slightly.